### PR TITLE
#1203 session_register was removed as of PHP 5.4, usage did not make any...

### DIFF
--- a/index.php.template
+++ b/index.php.template
@@ -1,6 +1,5 @@
 <?php
 // Session starten
-session_register(); 
 @session_start();
 
   // For the moment we are using ISO8859, should be changed to UTF-8 in the future...


### PR DESCRIPTION
... sense there anyway.
